### PR TITLE
Exit process if bash version is too old

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ cp funnychar /usr/local/bin/funnychar
 
 ## Usage
 
+You need Bash version 4 or above to run `funnychar`.
+
 ```bash
 $ ./funnychar.sh -p 3 "abcABC def"
 𝑎𝑏𝑐𝐴𝐵𝐶 𝑑𝑒𝑓

--- a/funnychar
+++ b/funnychar
@@ -13,6 +13,13 @@ help(){
   cat $0 |grep "^    \"[1-9]"|tr -d '"=;'|sed 's/CP/U+/g'
 }
 
+check_bash_version(){
+  [[ ${BASH_VERSION::1} < 4 ]] && {
+    echo 'You need to have bash v4 or above to use this tool.' >&2
+    exit 1
+  }
+}
+
 changecode(){
   declare -A funnytable
   funnytable[" "]=" "
@@ -94,6 +101,9 @@ changecode(){
   done
   echo
 }
+
+# If bash version is less than 4, exit.
+check_bash_version
 
 if echo "$@" |grep -e '^-h' -e '^--help' >/dev/null
 then


### PR DESCRIPTION
When I first ran this tool, I had the following output.

```
$ ./funnychar -p 1 hoge
/usr/local/bin/funnychar: line 17: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
ｚｚｚｚ
```

This error occurs when Bash is older than version 4, because as it says, `-A` of `declare` isn't available.
(I had macOS's default bash whose version is `3.2.57`)

I think it's more user-friendly to check bash's version before running, and I updated the script to do so.