### PR TITLE
Add: test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bash-version: ["3.0", 3.1, 3.2, "4.0", 4.1, 4.2, 4.3, 4.4, "5.0", 5.1]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Bash ${{ matrix.bash-version }}
+        run: |
+          git clone https://github.com/ueokande/bashvm $HOME/.bashvm
+          source $HOME/.bashvm/bin/bashvm-init
+          bashvm use --install ${{ matrix.bash-version }}
+      - name: Setup Bats
+        run: |
+          sudo apt install bats
+      - name: Install funnychar
+        run: |
+          sudo install -m 0755 funnychar /usr/local/bin/funnychar
+      - name: Run tests
+        run: |
+          chmod +x test.bats && ./test.bats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,11 @@ jobs:
       - name: Setup Bats
         run: |
           sudo apt install bats
+      - name: Setup faketty
+        uses: Yuri6037/Action-FakeTTY@v1.1
       - name: Install funnychar
         run: |
           sudo install -m 0755 funnychar /usr/local/bin/funnychar
       - name: Run tests
         run: |
-          chmod +x test.bats && ./test.bats
+          chmod +x test.bats && faketty bats test.bats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
           sudo install -m 0755 funnychar /usr/local/bin/funnychar
       - name: Run tests
         run: |
-          chmod +x test.bats && faketty bats test.bats
+          faketty bats test.bats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
           git clone https://github.com/ueokande/bashvm $HOME/.bashvm
           source $HOME/.bashvm/bin/bashvm-init
           bashvm use --install ${{ matrix.bash-version }}
+          bash --version | head -1
+          echo ${BASH_VERSION}
       - name: Setup Bats
         run: |
           sudo apt install bats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           source $HOME/.bashvm/bin/bashvm-init
           bashvm use --install ${{ matrix.bash-version }}
           bash --version | head -1
-          echo ${BASH_VERSION}
       - name: Setup Bats
         run: |
           sudo apt install bats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Setup Bash ${{ matrix.bash-version }}
         run: |
-          git clone https://github.com/ueokande/bashvm $HOME/.bashvm
+          git clone --depth 1 https://github.com/ueokande/bashvm $HOME/.bashvm
           source $HOME/.bashvm/bin/bashvm-init
           bashvm use --install ${{ matrix.bash-version }}
           bash --version | head -1

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ $ cp funnychar /usr/local/bin/funnychar
 
 ## Usage
 
-You need Bash version 4 or above to run `funnychar`.
-
 ```bash
 $ ./funnychar.sh -p 3 "abcABC def"
 𝑎𝑏𝑐𝐴𝐵𝐶 𝑑𝑒𝑓

--- a/funnychar
+++ b/funnychar
@@ -137,12 +137,6 @@ main(){
     RULE="$(get_p52 "$P")"
   fi
 
-  # bash version check
-  [[ ${BASH_VERSION::1} < 4 ]] && {
-    echo 'You need to have bash v4 or above to use this tool.' >&2
-    exit 1
-  }
-
   # Translation
   if [ -p /dev/stdin ]
   then

--- a/test.bats
+++ b/test.bats
@@ -1,19 +1,19 @@
 #!/usr/bin/env bats
 
-# @test "-p + arg 1" {
-#   run bash -c "funnychar -p 1 UNKO"
-#   [ "$output" = 'ＵＮＫＯ' ]
-# }
+@test "-p + arg 1" {
+  run bash -c "funnychar -p 1 UNKO"
+  [ "$output" = 'ＵＮＫＯ' ]
+}
 
-# @test "-p + arg 2" {
-#   run bash -c "funnychar -p 13 UNKO"
-#   [ "$output" = '𝙐𝙉𝙆𝙊' ]
-# }
+@test "-p + arg 2" {
+  run bash -c "funnychar -p 13 UNKO"
+  [ "$output" = '𝙐𝙉𝙆𝙊' ]
+}
 
-# @test "-u + arg" {
-#   run bash -c "funnychar -u U+1F1E6 UNKO"
-#   [ "$output" = '🇺🇳🇰🇴' ]
-# }
+@test "-u + arg" {
+  run bash -c "funnychar -u U+1F1E6 UNKO"
+  [ "$output" = '🇺🇳🇰🇴' ]
+}
 
 @test "-p + stdin 1" {
   run bash -c "echo UNKO|funnychar -p 1"

--- a/test.bats
+++ b/test.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# @test "-p + arg 1" {
+#   run bash -c "funnychar -p 1 UNKO"
+#   [ "$output" = 'ＵＮＫＯ' ]
+# }
+
+# @test "-p + arg 2" {
+#   run bash -c "funnychar -p 13 UNKO"
+#   [ "$output" = '𝙐𝙉𝙆𝙊' ]
+# }
+
+# @test "-u + arg" {
+#   run bash -c "funnychar -u U+1F1E6 UNKO"
+#   [ "$output" = '🇺🇳🇰🇴' ]
+# }
+
+@test "-p + stdin 1" {
+  run bash -c "echo UNKO|funnychar -p 1"
+  [ "$output" = 'ＵＮＫＯ' ]
+}
+
+@test "-p + stdin 2" {
+  run bash -c "echo UNKO|funnychar -p 20"
+  [ "$output" = '🇺🇳🇰🇴' ]
+}
+
+@test "-u + stdin" {
+  run bash -c "echo UNKO|funnychar -u U+1D400"
+  [ "$output" = '𝐔𝐍𝐊𝐎' ]
+}
+
+@test "-u + stdin + arg" {
+  run bash -c "echo UNKO|funnychar -p 10 UNCHI"
+  [ "$output" = '𝖴𝖭𝖪𝖮' ]
+}
+
+# error
+
+@test "-p (range error)" {
+  run bash -c "echo UNKO|funnychar -p 21"
+  [ "$status" -eq 1 ]
+}
+
+@test "-u (arg format error)" {
+  run bash -c "funnychar -u U1 UNKO"
+  [ "$status" -eq 1 ]
+}
+
+@test "-p + -u (opt error)" {
+  run bash -c "funnychar -u U+1F1E6 -p 1 UNKO"
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
GitHub ActionsによるPush毎テストを追加しました。
実行例: https://github.com/eggplants/funnychar/actions/runs/980851166
`Bash [3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 4.3, 4.4, 5.0, 5.1]`のテストが可能です。
しかし、GitHub Actions上で`[ -p /dev/stdin ]`が常に真となっているせいでテストが落ちるため、引数から変換する文字列を与えるテストはコメントアウトしています。